### PR TITLE
Fixes to DIGI,L1,RECO and Validation steps with GE21

### DIFF
--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
@@ -118,13 +118,10 @@ GEMGeometry* GEMGeometryBuilderFromDDD::buildGeometry(DDFilteredView& fv, const 
   // construct the regions, stations and rings. 
   for (int re = -1; re <= 1; re = re+2) {
     GEMRegion* region = new GEMRegion(re);
-    for (int st=1; st< GEMDetId::maxStationId; ++st) {
+    for (int st=1; st<=2; ++st) {
       GEMStation* station = new GEMStation(re, st);
       std::string sign( re==-1 ? "-" : "");
       std::string name("GE" + sign + std::to_string(st) + "/1");
-      // Closest (furthest) super chambers in GE2/1 are called GE2/1s (GE2/1l)
-      if (st==2) name = "GE" + sign + std::to_string(st) + "/1s";
-      if (st==3) name = "GE" + sign + std::to_string(st-1) + "/1l";
       station->setName(name);
       for (int ri=1; ri<=1; ++ri) {
 	GEMRing* ring = new GEMRing(re, st, ri);

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME21GEM.cc
@@ -205,7 +205,7 @@ CSCMotherboardME21GEM::run(const CSCWireDigiCollection* wiredc,
     //    const bool isEven(csc_id%2==0);
     const int region((theEndcap == 1) ? 1: -1);
     const bool isEven(csc_id.chamber()%2==0);
-    const GEMDetId gem_id_long(region, 1, 3, 1, csc_id.chamber(), 0);
+    const GEMDetId gem_id_long(region, 1, 2, 1, csc_id.chamber(), 0);
     const GEMChamber* gemChamberLong(gem_g->chamber(gem_id_long));
     
     // LUT<roll,<etaMin,etaMax> >    
@@ -971,7 +971,7 @@ void CSCMotherboardME21GEM::buildCoincidencePads(const GEMPadDigiCollection* out
 	id.ring() != csc_id.ring() or id.chamber() != csc_id.chamber()) continue;
 
     // build coincidences only for long superchamber pads
-    if (id.station() != 3) continue;
+    if (id.station() != 2) continue;
     
     // all coincidences detIDs will have layer=1
     if (id.layer() != 1) continue;
@@ -1006,7 +1006,7 @@ CSCMotherboardME21GEM::createGEMRollEtaLUT()
 {
   std::map<int,std::pair<double,double> > result;
 
-  auto chamber(gem_g->chamber(GEMDetId(1,1,3,1,1,0)));
+  auto chamber(gem_g->chamber(GEMDetId(1,1,2,1,1,0)));
   if (chamber==nullptr) return result;
 
   for(int i = 1; i<= chamber->nEtaPartitions(); ++i){

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.cc
@@ -34,7 +34,6 @@ GEMSegmentAlgorithm::GEMSegmentAlgorithm(const edm::ParameterSet& ps) : GEMSegme
   dEtaChainBoxMax           = ps.getParameter<double>("dEtaChainBoxMax");
   maxRecHitsInCluster       = ps.getParameter<int>("maxRecHitsInCluster");
   clusterOnlySameBXRecHits  = ps.getParameter<bool>("clusterOnlySameBXRecHits");
-  // useGE21Short              = ps.getParameter<bool>("useGE21Short"); --> needed in GEMSegmentBuilder.cc
 
   // maybe to be used in the future ???
   // Pruning                = ps.getParameter<bool>("Pruning");

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.h
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentAlgorithm.h
@@ -6,7 +6,7 @@
  *
  * This algorithm is very basic no attemp to deal with ambiguities , noise etc.
  * The GEM track segments (actually more correct would be: GEM correlated hits)
- * is built out of the rechits in two GEM layers (GE1/1) or three GEM layers (GE2/1)
+ * is built out of the rechits in two GEM layers in GE1/1 or GE2/1
  * as the GEM Ensabmle .<BR>
  *
  *  \authors Piet Verwilligen 
@@ -68,7 +68,6 @@ private:
   double  dEtaChainBoxMax;
   int     maxRecHitsInCluster;
   bool    clusterOnlySameBXRecHits;
-  // bool    useGE21Short;
   
   EnsembleHitContainer proto_segment;
   GEMDetId    theChamberId;

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.cc
@@ -22,9 +22,6 @@ GEMSegmentBuilder::GEMSegmentBuilder(const edm::ParameterSet& ps) : geom_(0) {
   // Ask factory to build this algorithm, giving it appropriate ParameterSet  
   algo = std::unique_ptr<GEMSegmentAlgorithmBase>(GEMSegmentBuilderPluginFactory::get()->create(algoName, segAlgoPSet));
   
-  // Use GE21Short to have 4 rechits available in GE21?
-  useGE21Short = ps.getParameter<bool>("useGE21Short");
-
 }
 GEMSegmentBuilder::~GEMSegmentBuilder() {}
 
@@ -42,22 +39,15 @@ void GEMSegmentBuilder::build(const GEMRecHitCollection* recHits, GEMSegmentColl
     // GEM Ensemble is defined by assigning all the GEMDetIds of the same "superchamber" 
     // (i.e. region same, chamber same) to the DetId of the first layer
 
-    // if use of GE21Short is prohibited and gemrechit is in station 2 quit the loop
-    if(!useGE21Short && it2->gemId().station()==2) continue;
-
     // here a reference GEMDetId is created: named "id"
     // - Ring 1 (no other rings available for GEM)
     // - Layer 1 = reference layer (effective layermask)
     // - Roll 0  = reference roll  (effective rollmask)
-    // - GE2/1 Long & Short needs to be combined => station = 2,3 ==> 3
-    // - Station == 1 (GE1/1) or == 3 (GE2/1)
+    // - Station == 1 (GE1/1) or == 2 (GE2/1)
     // this reference id serves to link all GEMEtaPartitions
     // and will also be used to determine the GEMSuperChamber 
     // to which the GEMSegment is assigned (done inside GEMSegAlgoXX)
-    int station = 0; 
-    if(it2->gemId().station()==1) station=1;
-    else if(it2->gemId().station()==2 || it2->gemId().station()==3) station=3;
-    GEMDetId id(it2->gemId().region(),1,station,0,it2->gemId().chamber(),0);
+    GEMDetId id(it2->gemId().region(),1,it2->gemId().station(),0,it2->gemId().chamber(),0);
     // save current GEMRecHit in vector associated to the reference id
     ensembleRH[id.rawId()].push_back(it2->clone());
   }
@@ -71,10 +61,7 @@ void GEMSegmentBuilder::build(const GEMRecHitCollection* recHits, GEMSegmentColl
     std::vector<GEMRecHit* > pp = enIt->second;
     std::vector<GEMRecHit*>::iterator ppit = pp.begin();
     GEMRecHit * pphit = (*ppit);
-    // !!! important !!! for GE2/1 make that the chamber is always in station 3
-    int chambidstat = pphit->gemId().station(); if(chambidstat==2) chambidstat=3;
-    // would layer = 0 work? actually it should ...
-    GEMDetId chamberid = GEMDetId(pphit->gemId().region(), 1, chambidstat, 0, pphit->gemId().chamber(), 0); 
+    GEMDetId chamberid = GEMDetId(pphit->gemId().region(), 1, pphit->gemId().station(), 0, pphit->gemId().chamber(), 0); 
     const GEMSuperChamber* chamber = geom_->superChamber(chamberid);
     for(auto rechit = enIt->second.begin(); rechit != enIt->second.end(); ++rechit) {
       gemRecHits.push_back(*rechit);

--- a/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.h
+++ b/RecoLocalMuon/GEMSegment/plugins/GEMSegmentBuilder.h
@@ -45,7 +45,6 @@ private:
     std::string algoName;
     edm::ParameterSet segAlgoPSet;
     std::unique_ptr<GEMSegmentAlgorithmBase> algo;
-    bool useGE21Short;
     const GEMGeometry* geom_; 
 };
 

--- a/RecoLocalMuon/GEMSegment/python/gemSegments_cfi.py
+++ b/RecoLocalMuon/GEMSegment/python/gemSegments_cfi.py
@@ -15,5 +15,4 @@ gemSegments = cms.EDProducer("GEMSegmentProducer",
         maxRecHitsInCluster = cms.int32(4),        # Does 4 make sense here?
         clusterOnlySameBXRecHits = cms.bool(True), # only working for (preClustering && preClusteringUseChaining)
     ),
-    useGE21Short = cms.bool(True),
 )

--- a/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
+++ b/SimMuon/GEMDigitizer/src/GEMSimpleModel.cc
@@ -218,7 +218,7 @@ void GEMSimpleModel::simulateNoise(const GEMEtaPartition* roll, CLHEP::HepRandom
                                       + GE11ElecBkgParam3 * rollRadius * rollRadius * rollRadius;
     averageNoiseRatePerRoll = averageNeutralNoiseRatePerRoll + averageNoiseElectronRatePerRoll;
   }
-  if (gemId.station() == 2 || gemId.station() == 3)
+  if (gemId.station() == 2)
   {
 //simulate neutral background for GE2/1
     if (simulateLowNeutralRate_)

--- a/Validation/MuonGEMDigis/src/GEMCheckGeometry.cc
+++ b/Validation/MuonGEMDigis/src/GEMCheckGeometry.cc
@@ -47,10 +47,6 @@ void GEMCheckGeometry::bookHistograms(DQMStore::IBooker & ibooker, edm::Run cons
         temp_me->setBinLabel(6,"St2,La1_odd",2);
         temp_me->setBinLabel(7,"St2,La2_even",2);
         temp_me->setBinLabel(8,"St2,La2_odd",2);
-        temp_me->setBinLabel(9,"St3,La1_even",2);
-        temp_me->setBinLabel(10,"St3,La1_odd",2);
-        temp_me->setBinLabel(11,"St3,La2_even",2);
-        temp_me->setBinLabel(12,"St3,La2_odd",2);
         theStdPlots.insert( std::map< UInt_t, MonitorElement*>::value_type(name.Hash(), temp_me ));
    }
 

--- a/Validation/MuonGEMDigis/src/GEMCoPadDigiValidation.cc
+++ b/Validation/MuonGEMDigis/src/GEMCoPadDigiValidation.cc
@@ -10,7 +10,6 @@ GEMCoPadDigiValidation::GEMCoPadDigiValidation(const edm::ParameterSet& cfg): GE
 }
 void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const & Run, edm::EventSetup const & iSetup ) {
   const GEMGeometry* GEMGeometry_ = initGeometry(iSetup);
-  //if ( nStationForLabel() ==3 ) setNStationForLabel(2) ;
 
   const double PI = TMath::Pi();
 
@@ -38,8 +37,6 @@ void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Ru
     }
     for( auto& station : region->stations()) {
       int st = station->station();
-      //if ( nStation()==3 && st ==2 ) continue;  // skip st2 short
-      //st = (station->station()==1) ? 1 : 2;   // 1 = station 1, 3 = station2l. Should be 2.
       TString title_suffix2 = getSuffixTitle( re , st) ;
       TString histname_suffix2 = getSuffixName( re, st) ;
 
@@ -61,8 +58,6 @@ void GEMCoPadDigiValidation::bookHistograms(DQMStore::IBooker & ibooker, edm::Ru
         for( auto& station : region->stations() ) {
           int st = station->station();
           int station_num = st-1;
-          //if ( nStation()==3 && st ==2 ) continue;  // skip st2 short
-          //st = (station->station()==1) ? 1 : 2;   // 1 = station 1, 3 = station2l. Should be 2.
             
           if ( st == 1 ) nPads = npadsGE11;
           else nPads = npadsGE21;
@@ -112,8 +107,6 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& e,
     return ;
   }
 
-
-  // Alert! copad's station2 means GEMGeometry's station3. 
   for (GEMCoPadDigiCollection::DigiRangeIterator cItr=gem_digis->begin(); cItr!=gem_digis->end(); cItr++) {
     GEMDetId id = (*cItr).first;
     int re = id.region();
@@ -124,8 +117,6 @@ void GEMCoPadDigiValidation::analyze(const edm::Event& e,
     //loop over digis of given roll
     for (digiItr = (*cItr ).second.first; digiItr != (*cItr ).second.second; ++digiItr)
     {
-      if ( st ==2 ) st = 3; // due to gap GEMGeometry and Copad's keep information.
-
       GEMDetId roId = GEMDetId(re, id.ring(), st, la, chamber, digiItr->roll());
       Short_t nroll = roId.roll();  
       LogDebug("GEMCoPadDigiValidation")<<"roId : "<<roId;


### PR DESCRIPTION
Hi Sunanda,

The fixes below ensure that step2 (DIGI,L1,DIGI2RAW,HLT) runs in the upgrade matrix tests (20024.0 and 20824.0). Step3 also runs although there are some minor things in the validation step that still need fixing. 

Can you please include this PR in your branch before cms-sw:PR15990 is merged?

Thanks
Sven
